### PR TITLE
Fix className prop

### DIFF
--- a/example/example.tsx
+++ b/example/example.tsx
@@ -7,11 +7,28 @@ const Box = createBox(atoms, usedProperties);
 
 const App = () => {
   return (
-    <div className={themeClass}>
-      <Box as="a" href="https://google.com" padding={{ desktop: 'extraLarge', mobile: 'small' }}>Hello</Box>
-    </div>
+    <Box className={themeClass}>
+      <Box
+        as="a"
+        href="https://google.com"
+        padding={{ desktop: 'extraLarge', mobile: 'small' }}
+      >
+        With atoms
+      </Box>
+
+      <Box
+        as="a"
+        href="https://google.com"
+        padding={{ desktop: 'extraLarge', mobile: 'small' }}
+        className="custom_class"
+      >
+        With atoms + className
+      </Box>
+
+      <Box>Without atoms or className</Box>
+    </Box>
   );
-}
+};
 
 const container = document.createElement('div');
 document.body.appendChild(container);

--- a/index.tsx
+++ b/index.tsx
@@ -9,19 +9,39 @@ export function createBox<AtomsFn extends (...args: any[]) => string>(atomsFn: A
 
   const usedPropertiesSet = new Set(usedProperties);
 
-  function Box({ as: Element = 'div', children, ...props }: BoxProps) {
+  function Box({
+    as: Element = 'div',
+    className,
+    children,
+    ...props
+  }: BoxProps) {
+    let hasAtomProps = false;
     let atomProps: Record<string, unknown> = {};
     let otherProps: Record<string, unknown> = {};
 
     Object.entries(props).map(([name, value]) => {
       if (usedPropertiesSet.has(name)) {
+        hasAtomProps = true;
         atomProps[name] = value;
       } else {
         otherProps[name] = value;
       }
     });
 
-    return <Element {...otherProps} className={atomsFn(atomProps)}>{children}</Element>
+    return (
+      <Element
+        {...otherProps}
+        className={
+          hasAtomProps || className
+            ? `${className ?? ''}${hasAtomProps && className ? ' ' : ''}${
+                hasAtomProps ? atomsFn(atomProps) : ''
+              }`
+            : undefined
+        }
+      >
+        {children}
+      </Element>
+    );
   }
 
   return Box as Polymorphic.ForwardRefComponent<'div', Omit<BoxProps, 'as'>>;


### PR DESCRIPTION
First of all, thanks for this awesome library 🙏

This PR fixes an issue where `className` props weren't being forwarded to the underlying node. I've added a few different examples to show how the combinations of atoms + className work together.