### PR TITLE
Update API to use atoms.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Install the package:
 $ npm install dessert-box
 ```
 
-> [`@radix-ui/react-polymorphic`](https://radix-ui.com/primitives/docs/utilities/polymorphic) is installed to get propert type hints.
-
 Configure [vanilla-extract](https://github.com/seek-oss/vanilla-extract) and [`sprinkles`](https://github.com/seek-oss/vanilla-extract/tree/master/packages/sprinkles) and have your atoms ready, and also export a flat array with all of the pieces that make up your atoms fn:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ A `<Box />` component to consume atoms created with [vanilla-extract](https://gi
 
 > Shout out to the team at Seek for making these awesome libraries!
 
+- [Dessert Box](#dessert-box)
+  - [Usage](#usage)
+  - [API](#api)
+    - [createBox(atoms: AtomsFn)](#createboxatoms-atomsfn)
+    - [createBoxWithAtomsProp(atoms: AtomsFn)](#createboxwithatomspropatoms-atomsfn)
+  - [TypeScript](#typescript)
+  - [Running the example app](#running-the-example-app)
+  - [How does it work?](#how-does-it-work)
+  - [Thanks](#thanks)
+
 ## Usage
 
 Install the package:
 
 ```
-$ npm install dessert-box @radix-ui/react-polymorphic
+$ npm install dessert-box
 ```
 
 > [`@radix-ui/react-polymorphic`](https://radix-ui.com/primitives/docs/utilities/polymorphic) is installed to get propert type hints.
@@ -62,6 +72,7 @@ Now let's create our `<Box />` using these atoms:
 
 ```jsx
 // yourApp.ts
+import { createBox } from 'dessert-box';
 const Box = createBox(atoms, usedProperties);
 
 const App = () => {
@@ -83,18 +94,49 @@ If you need to render a tag different than a `div`, you can use the `as` prop:
 </Box>
 ```
 
-### TypeScript
+## API
+
+### createBox(atoms: AtomsFn)
+
+Creates a `<Box />` component that takes atoms at the root level.
+
+```jsx
+import { createBox } from 'dessert-box';
+import { atoms } from './atoms.css';
+
+const box = createBox(atoms);
+
+<Box padding="small" />
+```
+
+### createBoxWithAtomsProp(atoms: AtomsFn)
+
+Creates a `<Box />` component that takes atoms as a prop called `atoms`.
+
+```jsx
+import { createBox } from 'dessert-box';
+import { atoms } from './atoms.css';
+
+const Box = createBoxWithAtomsProp(atoms);
+
+<Box atoms={{ padding: 'small' }} />
+```
+
+## TypeScript
 
 This library is fully typed, and the component supports the `as` prop, and will properly type props based on the type of element we use and also based on our atoms.
 
-Thanks to [`@radix-ui/react-polymorphic`](https://radix-ui.com/primitives/docs/utilities/polymorphic) for helping to achieve this :sparkles:.
-
-### Running the example app
+## Running the example app
 
 Run `npm install` then `npm run build` in the root folder (the one with this README file).
 
 Then move into the example folder `cd example` and run `npm install` and `npm start`.
 
-#### How does it work?
+## How does it work?
 
 This works by depending on build-time generated CSS by [sprinkles](https://github.com/seek-oss/vanilla-extract/tree/3360bdfc9220024e7ffa49b3b198b72743d4e264/packages/sprinkles), and then using the `atomsFn` function to lookup classNames in runtime. So it does have a runtime footprint, but should be pretty minimal. I'm still experimenting to see if it's possible to remove that, but other approaches may lead to other constraints or similar runtime.
+
+## Thanks
+
+- Thanks to the team at Seek for [vanilla-extract](https://github.com/seek-oss/vanilla-extract) and [`sprinkles`](https://github.com/seek-oss/vanilla-extract/tree/master/packages/sprinkles), this would not be possible without these great libs and the technical feats they accomplish.
+- Thanks to the team at Modulz for [`@radix-ui/react-polymorphic`](https://radix-ui.com/primitives/docs/utilities/polymorphic). The component offers a great typed experience thanks to this.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dessert Box
+# 🍰 Dessert Box
 
 > Carefully packaged with sweets and atomic energy!
 
@@ -6,7 +6,7 @@ A `<Box />` component to consume atoms created with [vanilla-extract](https://gi
 
 > Shout out to the team at Seek for making these awesome libraries!
 
-- [Dessert Box](#dessert-box)
+- [🍰 Dessert Box](#-dessert-box)
   - [Usage](#usage)
   - [API](#api)
     - [createBox(atoms: AtomsFn)](#createboxatoms-atomsfn)

--- a/example/atoms.css.ts
+++ b/example/atoms.css.ts
@@ -62,6 +62,4 @@ const colorStyles = createAtomicStyles({
   }
 });
 
-export const usedProperties = [colorStyles, layoutStyles].flatMap(item => Object.keys(item));
-
 export const atoms = createAtomsFn(layoutStyles, colorStyles);

--- a/example/example.tsx
+++ b/example/example.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createBox } from '../dist/index';
-import { themeClass, atoms, usedProperties } from './atoms.css';
+import { createBox, createBoxWithAtomsProp } from '../dist/index';
+import { themeClass, atoms } from './atoms.css';
 
-const Box = createBox(atoms, usedProperties);
+const Box = createBox(atoms);
+const BoxWithAtomsProp = createBoxWithAtomsProp(atoms);
 
 const App = () => {
   return (
@@ -26,6 +27,16 @@ const App = () => {
       </Box>
 
       <Box>Without atoms or className</Box>
+
+      <BoxWithAtomsProp
+        as="a"
+        href="https://google.com"
+        atoms={{
+          padding: { desktop: 'extraLarge', mobile: 'small' }
+        }}
+      >
+        With atoms as a prop
+      </BoxWithAtomsProp>
     </Box>
   );
 };

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -144,9 +144,9 @@
       "integrity": "sha512-80sIzAcjya/b+qradMsIcCGwAxLLqsLDMk8Hj1trJtKZOkz+JMHNi5kHwjy+7nZP84uUzrmUXkvG4gBfqc8LNg=="
     },
     "@vanilla-extract/sprinkles": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@vanilla-extract/sprinkles/-/sprinkles-0.1.1.tgz",
-      "integrity": "sha512-E9LN0gTCLaxtvqTBMYNjdzBtB2Mtyzzxdn7jD/R8CXg4Wc/RwLU2OTvKSN+FL3/faXr+aLQBhOiMO4e2exHOsQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/sprinkles/-/sprinkles-0.2.0.tgz",
+      "integrity": "sha512-Wqi1leNYDuFTVuEz4rAq86ulOa4zvpqQ6XCk+lxs0mGOrNx1YCQEqtBPXJ4epOHUD/oyz+iUek91U5PbqnXddw=="
     },
     "@zeit/schemas": {
       "version": "2.6.0",

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^17.0.3",
     "@vanilla-extract/css": "^0.4.1",
     "@vanilla-extract/esbuild-plugin": "^0.2.1",
-    "@vanilla-extract/sprinkles": "^0.1.1",
+    "@vanilla-extract/sprinkles": "^0.2.0",
     "concurrently": "^6.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/index.tsx
+++ b/index.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
-export function createBox<AtomsFn extends (...args: any[]) => string>(atomsFn: AtomsFn, usedProperties: string[]) {
+interface AtomsFnBase {
+  (...args: any): string;
+  properties: Set<string>;
+}
+
+export function createBox<AtomsFn extends AtomsFnBase>(atomsFn: AtomsFn) {
   type BoxProps = {
     as?: keyof JSX.IntrinsicElements;
     children: any;
+    className?: string;
   } & Parameters<AtomsFn>[0];
-
-  const usedPropertiesSet = new Set(usedProperties);
 
   function Box({
     as: Element = 'div',
@@ -20,7 +24,7 @@ export function createBox<AtomsFn extends (...args: any[]) => string>(atomsFn: A
     let otherProps: Record<string, unknown> = {};
 
     Object.entries(props).map(([name, value]) => {
-      if (usedPropertiesSet.has(name)) {
+      if (atomsFn.properties.has(name)) {
         hasAtomProps = true;
         atomProps[name] = value;
       } else {
@@ -35,6 +39,42 @@ export function createBox<AtomsFn extends (...args: any[]) => string>(atomsFn: A
           hasAtomProps || className
             ? `${className ?? ''}${hasAtomProps && className ? ' ' : ''}${
                 hasAtomProps ? atomsFn(atomProps) : ''
+              }`
+            : undefined
+        }
+      >
+        {children}
+      </Element>
+    );
+  }
+
+  return Box as Polymorphic.ForwardRefComponent<'div', Omit<BoxProps, 'as'>>;
+}
+
+export function createBoxWithAtomsProp<AtomsFn extends AtomsFnBase>(atomsFn: AtomsFn) {
+  type BoxProps = {
+    as?: keyof JSX.IntrinsicElements;
+    children: any;
+    className?: string;
+    atoms?: Parameters<AtomsFn>[0]
+  };
+
+  function Box({
+    as: Element = 'div',
+    className,
+    children,
+    atoms,
+    ...props
+  }: BoxProps) {
+    const hasAtomProps = typeof atoms !== 'undefined';
+
+    return (
+      <Element
+        {...props}
+        className={
+          hasAtomProps || className
+            ? `${className ?? ''}${hasAtomProps && className ? ' ' : ''}${
+                hasAtomProps ? atomsFn(atoms) : ''
               }`
             : undefined
         }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "@radix-ui/react-polymorphic": "0.0.11"
+  },
   "devDependencies": {
-    "@radix-ui/react-polymorphic": "0.0.11",
     "@types/react": "^17.0.4",
     "esbuild": "^0.11.17",
     "react": "^17.0.2",


### PR DESCRIPTION
* Updates internal API to use `sprinkles` new `atoms.properties` ✨ 
* Exposes a new API `createBoxWithAtomsProp` to create a similar Box component that instead of taking atoms at the root level, takes these as a `atoms` prop.