### PR TITLE
Build: set target (Fixes #4)

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,6 +6,7 @@ require('esbuild').build({
   outdir: 'dist',
   sourcemap: true,
   format: 'cjs',
+  target: ['es2019'],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,7 +6,7 @@ require('esbuild').build({
   outdir: 'dist',
   sourcemap: true,
   format: 'cjs',
-  target: ['es2019'],
+  target: ['es2018'],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),


### PR DESCRIPTION
Issue: #4 

Ref: https://esbuild.github.io/content-types/#javascript

This fixes the transform of the nullish coalescing operator. Not sure this is the "correct" setting.

My project with babel presets of `["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]` works with this. I'm on Node16 though, I guess that also plays into this. To be safe we could set the target to something like "node14" which also transpiles the rest spread operator and some others.