### PR TITLE
Fix class='undefined'

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,15 +37,16 @@ export function createBox<AtomsFn extends AtomsFnBase>({
         }
       }
 
+      const classes = [
+        defaultClassName,
+        className,
+        hasAtomProps && atomsFn(atomProps),
+      ].filter(Boolean);
+
       return createElement(element, {
         ref,
         ...otherProps,
-        className:
-          (hasAtomProps || className
-            ? `${className ?? ""}${hasAtomProps && className ? " " : ""}${
-                hasAtomProps ? atomsFn(atomProps) : ""
-              }`
-            : undefined) + (defaultClassName ? ` ${defaultClassName}` : ""),
+        className: classes.length === 0 ? undefined : classes.join(" "),
       });
     }
   );


### PR DESCRIPTION
Currently, `<Box>Hello</Box>` results in `<div class="undefined">Hello</div>` because we do `undefined + ""` [here](https://github.com/TheMightyPenguin/dessert-box/blob/a948b4f4aa701f83c4d2a40f95b3477b9e7c48d0/src/index.tsx#L48).
With this fix, the result is simply `<div>Hello</div>`.