### PR TITLE
Allow react ^17 in peer dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,12 +20,12 @@
   "keywords": [],
   "devDependencies": {
     "@types/react": "^17.0.4",
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "dependencies": {
     "@dessert-box/core": "^0.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
As it stands, if you try to install `dessert-box` in a react 17 project, you get peer dependency conflicts. This PR adds support for react 17 :)

- [x] Tests pass