### PR TITLE
feat: escape hatch typings

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,7 +12,7 @@ type HTMLProperties = Omit<
 >;
 
 type OverrideTokens<T> = {
-  [K in keyof T as K extends string ? `__${K}` : number]: any;
+  [K in keyof T as K extends string ? `__${K}` : number]: Extract<T[K], string|number> | {};
 };
 
 export function createBox<AtomsFn extends AtomsFnBase>({


### PR DESCRIPTION
Hey, this PR adds autocomplete typing support on the `__` escape hatch while leaving the possibility to freely use untyped values.

<img width="624" alt="Screenshot 2022-06-28 at 10 30 49" src="https://user-images.githubusercontent.com/47224540/176132626-91f876d4-c3a8-43d1-948b-940915418afe.png">
<img width="595" alt="Screenshot 2022-06-28 at 10 31 09" src="https://user-images.githubusercontent.com/47224540/176132703-2528ba15-4f81-4cfb-aba2-d750fb26089a.png">
<img width="531" alt="Screenshot 2022-06-28 at 10 31 34" src="https://user-images.githubusercontent.com/47224540/176132797-ad8b329a-7bbb-4033-a04a-7114b2289ed8.png">

