### PR TITLE
Add Solid support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
+  babelrcRoots: ['.', 'packages/*'],
   presets: [
     '@babel/preset-typescript',
-    '@babel/preset-react',
     ['@babel/preset-env', { targets: { node: 12 } }],
   ],
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
-    "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
     "@preconstruct/cli": "^2.1.4",
     "@types/jest": "^27.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,5 +13,8 @@
     "url": "https://github.com/TheMightyPenguin/dessert-box.git",
     "directory": "packages/core"
   },
-  "keywords": []
+  "keywords": [],
+  "dependencies": {
+    "solid-js": "^1.7.8"
+  }
 }

--- a/packages/react/.babelrc.json
+++ b/packages/react/.babelrc.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/packages/solid/.babelrc.json
+++ b/packages/solid/.babelrc.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["solid", { "generate": "ssr", "hydratable": true }]]
+}

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,256 @@
+# 🍰 Dessert Box
+
+A library to easily consume your design tokens from a React component, meant to be used with [vanilla-extract][vanilla-extract].
+
+This library will make consuming your [sprinkles][sprinkles] from a react component a breeze. It provides a zero-CSS-runtime `<Box />` component (similar to the one in [Braid](https://seek-oss.github.io/braid-design-system/components/Box) or [Chakra](https://chakra-ui.com/docs/layout/box)).
+
+[Try it on CodeSandbox!](https://codesandbox.io/s/dessert-box-demo-wxgy8?file=/src/App.tsx)
+
+It works by consuming `atoms` created with [`vanilla-extract`][vanilla-extract]) and [`sprinkles`][sprinkles]. Shout out to the team at Seek for making these awesome libraries!
+
+1. Step 1, create your Box with your `atoms` created with sprinkles:
+
+```tsx
+// Box.tsx
+import { createBox } from '@dessert-box/react';
+import { atoms } from './sprinkles.css';
+
+const { Box } = createBox({
+  atoms,
+  // optional: pass your CSS reset className here
+  // useful if you want to scope your reset to your Box element
+  defaultClassName: 'resetClassName',
+});
+
+export default Box;
+```
+
+2. Step 2, import it enjoy the sweetness:
+
+```tsx
+// OtherFileOrComponent.tsx
+import Box from './Box';
+
+const MyComponent = () => {
+  return <Box padding="large">What a sweet treat!</Box>;
+};
+```
+
+**Wondering why using a Box component may be a good idea? or what is a Box component? Check the [FAQ](#FAQ).**
+
+> Wondering how to use `variants` with this library? Check out the [variants](#variants) section.
+
+![dessert-box](https://img.shields.io/bundlephobia/minzip/dessert-box.svg)
+
+- [🍰 Dessert Box](#-dessert-box)
+  - [Usage](#usage)
+    - [Variants](#variants)
+  - [API](#api)
+    - [createBox(options: { atoms: AtomsFn, defaultClassName?: string })](#createboxoptions--atoms-atomsfn-defaultclassname-string-)
+    - [createBoxWithAtomsProp(options: { atoms: AtomsFn, defaultClassName?: string })](#createboxwithatomspropoptions--atoms-atomsfn-defaultclassname-string-)
+  - [Running the example app](#running-the-example-app)
+  - [How does it work?](#how-does-it-work)
+  - [Thanks](#thanks)
+  - [FAQ](#faq)
+
+[Try it on CodeSandbox!](https://codesandbox.io/s/dessert-box-demo-wxgy8?file=/src/App.tsx)
+
+## Usage
+
+Install the package:
+
+```
+$ npm install @dessert-box/react
+```
+
+Configure [vanilla-extract](https://github.com/seek-oss/vanilla-extract) and [`sprinkles`](https://github.com/seek-oss/vanilla-extract/tree/master/packages/sprinkles) and have your atoms ready:
+
+```js
+// atoms.css.ts
+import { defineProperties, createSprinkles } from '@vanilla-extract/sprinkles';
+
+const space = {
+  none: 0,
+  small: 4,
+  medium: 8,
+  large: 16,
+};
+
+const colors = {
+  primary: 'blue',
+  // ...
+};
+
+const atomicStyles = defineProperties({
+  conditions: {
+    mobile: {},
+    tablet: { '@media': 'screen and (min-width: 768px)' },
+    desktop: { '@media': 'screen and (min-width: 1024px)' },
+  },
+  properties: {
+    padding: space,
+    backgroundColor: colors,
+    // ...
+  },
+  // ...
+});
+
+export const atoms = createSprinkles(atomicStyles);
+```
+
+> Check `sprinkles` [docs](https://github.com/seek-oss/vanilla-extract/tree/3360bdfc9220024e7ffa49b3b198b72743d4e264/packages/sprinkles#setup) for more context into how to create these atoms.
+
+Now let's create our `<Box />` using these atoms:
+
+```tsx
+// Box.ts
+import { createBox } from '@dessert-box/react';
+import { atoms } from './sprinkles.css';
+
+const { Box } = createBox({ atoms });
+
+export default Box;
+```
+
+```tsx
+// otherFile.tsx
+import Box from './Box';
+
+const App = () => {
+  return <Box padding="large">Hello</Box>;
+};
+```
+
+Notice we can pass every property, shorthand, or condition we can normally pass to our `atomsFn` function. For example, we could leverage the conditions for responsive design we have here:
+
+```jsx
+<Box padding={{ mobile: 'none', tablet: 'small', desktop: 'large' }} />
+```
+
+If you need to render a tag different than a `div`, you can use the `as` prop:
+
+```jsx
+<Box as="a" href="https://example.com" padding="small">
+  Link to example
+</Box>
+```
+
+[Try it on CodeSandbox!](https://codesandbox.io/s/dessert-box-demo-wxgy8?file=/src/App.tsx)
+
+### Variants
+
+The official [@vanilla-extract/recipes][recipes] package has an excelent API for dealing with variants, this can be combined with our `Box` component to create [variant-based components](https://ped.ro/blog/variant-driven-components):
+
+NOTE: (Assuming you already have created your `Box` component following the example above).
+
+1. First define your recipe using the `recipe` function:
+
+```tsx
+// Button.css.ts
+import { recipe } from '@vanilla-extract/recipes';
+import { atoms } from '../atoms.css';
+
+export const buttonRecipe = recipe({
+  variants: {
+    kind: {
+      primary: atoms({ background: 'blue50' }),
+      secondary: atoms({ background: 'yellow' }),
+    },
+    size: {
+      md: atoms({ fontSize: 'large' }),
+      lg: atoms({ fontSize: 'extraLarge' }),
+    },
+  },
+});
+
+export type ButtonVariants = Parameters<typeof buttonRecipe>[0];
+```
+
+2. Then use the `recipes` function to create variants and apply them to your `Box`:
+
+```tsx
+// Button.tsx
+import { Box } from './Box';
+import { buttonRecipe, ButtonVariants } from './Button.css';
+
+type Props = {
+  children: React.ReactNode;
+} & ButtonVariants;
+
+export const Button = ({
+  children,
+  size = 'md',
+  kind = 'secondary',
+}: Props) => {
+  return (
+    <Box as="button" className={buttonRecipe({ size, kind })}>
+      {children}
+    </Box>
+  );
+};
+
+export default Button;
+```
+
+For more context, refer to [@vanilla-extract/recipe][recipes] or feel free [to open an issue in this project](https://github.com/TheMightyPenguin/dessert-box/issues/new) if the integration is not working as you'd expect!
+
+## API
+
+### createBox(options: { atoms: AtomsFn, defaultClassName?: string })
+
+Creates a `<Box />` component that takes atoms at the root level.
+
+```jsx
+import { createBox } from '@dessert-box/react';
+import { atoms } from './atoms.css';
+
+const Box = createBox({ atoms });
+
+<Box padding="small" />;
+```
+
+### createBoxWithAtomsProp(options: { atoms: AtomsFn, defaultClassName?: string })
+
+Creates a `<Box />` component that takes atoms as a prop called `atoms`.
+
+```jsx
+import { createBoxWithAtomsProp } from '@dessert-box/react';
+import { atoms } from './atoms.css';
+
+const Box = createBoxWithAtomsProp({ atoms });
+
+<Box atoms={{ padding: 'small' }} />;
+```
+
+## Running the example app
+
+Run `npm install` then `npm run build` in the root folder (the one with this README file).
+
+Then move into the example folder `cd example` and run `npm install` and `npm start`.
+
+## How does it work?
+
+This works by depending on build-time generated CSS by [sprinkles](https://github.com/seek-oss/vanilla-extract/tree/3360bdfc9220024e7ffa49b3b198b72743d4e264/packages/sprinkles), and then using the `atomsFn` function to lookup classNames in runtime. So it does have a runtime footprint, but should be pretty minimal. I'm still experimenting to see if it's possible to remove that, but other approaches may lead to other constraints or similar runtime.
+
+## Thanks
+
+- Thanks to the team at Seek for [vanilla-extract](https://github.com/seek-oss/vanilla-extract) and [`sprinkles`](https://github.com/seek-oss/vanilla-extract/tree/master/packages/sprinkles), this would not be possible without these great libs and the technical feats they accomplish.
+
+## FAQ
+
+- What is a Box component?
+
+> It's a generic element that allows you to prototype fast and takes a variety of styling props (think of exposing a lot of CSS attributes as props on a component).
+
+- Why should I use a Box component?
+
+> There are many versions and flavors of a Box component, some are more [flexible](https://chakra-ui.com/docs/layout/box), while others are more [restrictive](https://seek-oss.github.io/braid-design-system/components/Box). The Box in this library falls into the latter category (restrictive), and it's more geared towards being the a lower level API of your Design System (or serving as inspiration for it).
+
+This Box component is meant to be used as a primitive for consuming design tokens, giving you a nice balance between flexibility and constraints. You can use it as an lower level API to implement your other components (Buttons, Card, Layout components, ...), and also as a prototyping and general usage component:
+
+- As a prototyping tool, it allows you to use all of your design tokens to generate new designs and evaluate if you need to iterate on your foundations, or to validate if they work for your use cases.
+- For general usage you can still have the guarantee that users of your system won't do anything impossible (e.g.: using a value that is not part of the design tokens) but still have a productive experience working on UI.
+
+[sprinkles]: https://github.com/seek-oss/vanilla-extract/tree/master/packages/sprinkles
+[vanilla-extract]: https://github.com/seek-oss/vanilla-extract
+[recipes]: https://github.com/seek-oss/vanilla-extract#recipes-api

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,8 +1,8 @@
 # 🍰 Dessert Box
 
-A library to easily consume your design tokens from a React component, meant to be used with [vanilla-extract][vanilla-extract].
+A library to easily consume your design tokens from a Solid component, meant to be used with [vanilla-extract][vanilla-extract].
 
-This library will make consuming your [sprinkles][sprinkles] from a react component a breeze. It provides a zero-CSS-runtime `<Box />` component (similar to the one in [Braid](https://seek-oss.github.io/braid-design-system/components/Box) or [Chakra](https://chakra-ui.com/docs/layout/box)).
+This library will make consuming your [sprinkles][sprinkles] from a Solid component a breeze. It provides a zero-CSS-runtime `<Box />` component (similar to the one in [Braid](https://seek-oss.github.io/braid-design-system/components/Box) or [Chakra](https://chakra-ui.com/docs/layout/box)).
 
 [Try it on CodeSandbox!](https://codesandbox.io/s/dessert-box-demo-wxgy8?file=/src/App.tsx)
 
@@ -12,7 +12,7 @@ It works by consuming `atoms` created with [`vanilla-extract`][vanilla-extract])
 
 ```tsx
 // Box.tsx
-import { createBox } from '@dessert-box/react';
+import { createBox } from '@dessert-box/solid';
 import { atoms } from './sprinkles.css';
 
 const { Box } = createBox({
@@ -60,7 +60,7 @@ const MyComponent = () => {
 Install the package:
 
 ```
-$ npm install @dessert-box/react
+$ npm install @dessert-box/solid
 ```
 
 Configure [vanilla-extract](https://github.com/seek-oss/vanilla-extract) and [`sprinkles`](https://github.com/seek-oss/vanilla-extract/tree/master/packages/sprinkles) and have your atoms ready:
@@ -104,7 +104,7 @@ Now let's create our `<Box />` using these atoms:
 
 ```tsx
 // Box.ts
-import { createBox } from '@dessert-box/react';
+import { createBox } from '@dessert-box/solid';
 import { atoms } from './sprinkles.css';
 
 const { Box } = createBox({ atoms });
@@ -171,10 +171,11 @@ export type ButtonVariants = Parameters<typeof buttonRecipe>[0];
 ```tsx
 // Button.tsx
 import { Box } from './Box';
+import type { ParentProps } from "solid-js"
 import { buttonRecipe, ButtonVariants } from './Button.css';
 
 type Props = {
-  children: React.ReactNode;
+  children: ParentProps;
 } & ButtonVariants;
 
 export const Button = ({
@@ -201,7 +202,7 @@ For more context, refer to [@vanilla-extract/recipe][recipes] or feel free [to o
 Creates a `<Box />` component that takes atoms at the root level.
 
 ```jsx
-import { createBox } from '@dessert-box/react';
+import { createBox } from '@dessert-box/solid';
 import { atoms } from './atoms.css';
 
 const Box = createBox({ atoms });
@@ -214,7 +215,7 @@ const Box = createBox({ atoms });
 Creates a `<Box />` component that takes atoms as a prop called `atoms`.
 
 ```jsx
-import { createBoxWithAtomsProp } from '@dessert-box/react';
+import { createBoxWithAtomsProp } from '@dessert-box/solid';
 import { atoms } from './atoms.css';
 
 const Box = createBoxWithAtomsProp({ atoms });

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "@dessert-box/react",
+  "name": "@dessert-box/solid",
   "version": "0.7.5",
   "description": "",
   "author": "Victor Tortolero <victormtortolero@gmail.com>",
-  "main": "dist/dessert-box-react.cjs.js",
-  "module": "dist/dessert-box-react.esm.js",
-  "types": "dist/dessert-box-react.cjs.d.ts",
+  "main": "dist/dessert-box-solid.cjs.js",
+  "module": "dist/dessert-box-solid.esm.js",
+  "types": "dist/dessert-box-solid.cjs.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "module": "./dist/dessert-box-react.esm.js",
-      "default": "./dist/dessert-box-react.cjs.js"
+      "module": "./dist/dessert-box-solid.esm.js",
+      "default": "./dist/dessert-box-solid.cjs.js"
     },
     "./styledRuntime": {
-      "module": "./styledRuntime/dist/dessert-box-react-styledRuntime.esm.js",
-      "default": "./styledRuntime/dist/dessert-box-react-styledRuntime.cjs.js"
+      "module": "./styledRuntime/dist/dessert-box-solid-styledRuntime.esm.js",
+      "default": "./styledRuntime/dist/dessert-box-solid-styledRuntime.cjs.js"
     }
   },
   "files": [
@@ -23,8 +23,8 @@
   ],
   "preconstruct": {
     "entrypoints": [
-      "index.ts",
-      "styledRuntime.ts"
+      "index.tsx",
+      "styledRuntime.tsx"
     ]
   },
   "sideEffects": false,
@@ -32,18 +32,16 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/TheMightyPenguin/dessert-box.git",
-    "directory": "packages/react"
+    "directory": "packages/solid"
   },
   "keywords": [],
   "devDependencies": {
-    "@types/react": "^17.0.4",
-    "@babel/preset-react": "^7.14.5",
     "@vanilla-extract/css": "^1.11.0",
-    "react": ">=16.8.0"
+    "babel-preset-solid": "^1.7.7"
   },
   "peerDependencies": {
     "@vanilla-extract/css": ">=1.11.0",
-    "react": ">=16.8.0"
+    "solid-js": "^1.7.8"
   },
   "dependencies": {
     "@dessert-box/core": "workspace:0.2.0"

--- a/packages/solid/pnpm-lock.yaml
+++ b/packages/solid/pnpm-lock.yaml
@@ -1,0 +1,57 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@dessert-box/core': ^0.2.0
+  '@types/react': ^17.0.4
+  react: '>=16.8.0'
+
+dependencies:
+  '@dessert-box/core': 0.2.0
+
+devDependencies:
+  '@types/react': 17.0.52
+  react: 18.2.0
+
+packages:
+
+  /@dessert-box/core/0.2.0:
+    resolution: {integrity: sha512-Vqaec6i0cvS1r54kU6CfOQECi6dPWzz6DVVxJABOxqPmVk8fOSy6pIKsK0YyPFGRpZK/FXkJ1YhURUOW1OxOVQ==}
+    dev: false
+
+  /@types/prop-types/15.7.5:
+    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+    dev: true
+
+  /@types/react/17.0.52:
+    resolution: {integrity: sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.2
+      csstype: 3.1.1
+    dev: true
+
+  /@types/scheduler/0.16.2:
+    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
+    dev: true
+
+  /csstype/3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+    dev: true
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /loose-envify/1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
+  /react/18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,0 +1,123 @@
+import {
+  AtomsFnBase,
+  composeClassNames,
+  extractAtomsFromProps,
+} from '@dessert-box/core';
+import {
+  ComponentProps,
+  createMemo,
+  JSX,
+  ParentProps,
+  splitProps,
+  ValidComponent,
+} from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import type { CreateBoxParams } from './types';
+
+export { styled } from './styled';
+
+type AsProp<TType extends ValidComponent = ValidComponent> = {
+  as?: TType;
+};
+type BaseBoxProps<TType extends ValidComponent> = AsProp<TType> &
+  Omit<ComponentProps<TType>, keyof AsProp>;
+
+type PolymorphicComponentProps<TType extends ValidComponent, Props> = Props &
+  BaseBoxProps<TType>;
+
+type OverrideTokens<T> = {
+  [K in keyof T as K extends string ? `__${K}` : number]:
+    | Extract<T[K], string | number>
+    | {};
+};
+
+type Tokens<AtomsFn extends AtomsFnBase> = Parameters<AtomsFn>[0];
+type BoxProps<
+  AtomsFn extends AtomsFnBase,
+  TType extends ValidComponent,
+> = PolymorphicComponentProps<
+  TType,
+  Tokens<AtomsFn> & OverrideTokens<JSX.CSSProperties>
+>;
+
+type BoxWithAtomsProps<
+  AtomsFn extends AtomsFnBase,
+  TType extends ValidComponent,
+> = PolymorphicComponentProps<
+  TType,
+  { atoms?: Tokens<AtomsFn> & OverrideTokens<Tokens<AtomsFn>> }
+>;
+
+let defaultElement = 'div';
+
+export function createBox<AtomsFn extends AtomsFnBase>({
+  atoms: atomsFn,
+  defaultClassName,
+}: CreateBoxParams<AtomsFn>) {
+  let Box = (
+    props: ParentProps<
+      {
+        as?: ValidComponent;
+        class?: string;
+        style?: JSX.CSSProperties;
+        ref?: HTMLElement;
+        //atoms?: Tokens<AtomsFn> & OverrideTokens<Tokens<AtomsFn>>;
+      } & BoxProps<AtomsFn, typeof defaultElement>
+    >,
+  ) => {
+    let [local, others] = splitProps(props, ['as', 'class', 'style', 'ref']);
+    let Element = local.as || defaultElement;
+
+    let classProps = createMemo(() => extractAtomsFromProps(others, atomsFn));
+
+    return (
+      <Dynamic
+        component={Element}
+        ref={local.ref}
+        style={{ ...local.style, ...classProps().customProps }}
+        class={composeClassNames(
+          local.class,
+          atomsFn(classProps().atomProps),
+          defaultClassName,
+        )}
+        {...classProps().otherProps}
+      />
+    );
+  };
+
+  return Box;
+}
+
+export function createBoxWithAtomsProp<AtomsFn extends AtomsFnBase>({
+  atoms: atomsFn,
+  defaultClassName,
+}: CreateBoxParams<AtomsFn>) {
+  let Box = (
+    props: ParentProps<
+      {
+        as?: ValidComponent;
+        class?: string;
+        style?: JSX.CSSProperties;
+        ref?: HTMLElement;
+      } & BoxWithAtomsProps<AtomsFn, typeof defaultElement>
+    >,
+  ) => {
+    let [local, others] = splitProps(props, ['as', 'class', 'ref', 'atoms']);
+    let Element = local.as || defaultElement;
+
+    return (
+      <Dynamic
+        component={Element}
+        ref={local.ref}
+        class={composeClassNames(
+          local.class,
+          atomsFn(local.atoms),
+          defaultClassName,
+        )}
+        {...others}
+      />
+    );
+  };
+
+  return Box;
+}

--- a/packages/solid/src/styled.ts
+++ b/packages/solid/src/styled.ts
@@ -1,0 +1,20 @@
+import { addFunctionSerializer } from '@vanilla-extract/css/functionSerializer';
+import { ComplexStyleRule, style } from '@vanilla-extract/css';
+import { styledRuntime } from './styledRuntime';
+import { ValidComponent } from 'solid-js';
+
+export function styled(el: ValidComponent, rules: ComplexStyleRule) {
+  let className = style(rules);
+  let args = [el, className] as const;
+
+  let Component = styledRuntime(el, className);
+
+  addFunctionSerializer(Component, {
+    importPath: '@dessert-box/solid/styledRuntime',
+    importName: 'styledRuntime',
+    // TODO: Fix this type, was complaining about string not being assignable to Serializable from VE lib
+    args: args as any,
+  });
+
+  return Component;
+}

--- a/packages/solid/src/styledRuntime.tsx
+++ b/packages/solid/src/styledRuntime.tsx
@@ -1,0 +1,20 @@
+import { ParentComponent, splitProps, ValidComponent, JSX } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+
+export function styledRuntime(el: ValidComponent, className: string) {
+  let Component: ParentComponent<{
+    class?: string;
+    style?: JSX.CSSProperties;
+  }> = (props) => {
+    let [local, others] = splitProps(props, ['class']);
+
+    return (
+      <Dynamic
+        component={el}
+        class={[local.class, className].filter(Boolean).join(' ')}
+        {...others}
+      />
+    );
+  };
+  return Component;
+}

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -1,0 +1,4 @@
+export type CreateBoxParams<AtomsFn> = {
+  atoms: AtomsFn;
+  defaultClassName?: string;
+};

--- a/packages/solid/styledRuntime/package.json
+++ b/packages/solid/styledRuntime/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/dessert-box-solid-styledRuntime.cjs.js",
+  "module": "dist/dessert-box-solid-styledRuntime.esm.js"
+}

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,11 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2
 
-  packages/core: {}
+  packages/core:
+    dependencies:
+      solid-js:
+        specifier: ^1.7.8
+        version: 1.7.8
 
   packages/react:
     dependencies:
@@ -95,6 +99,22 @@ importers:
       react:
         specifier: '>=16.8.0'
         version: 18.2.0
+
+  packages/solid:
+    dependencies:
+      '@dessert-box/core':
+        specifier: workspace:0.2.0
+        version: link:../core
+      solid-js:
+        specifier: ^1.7.8
+        version: 1.7.8
+    devDependencies:
+      '@vanilla-extract/css':
+        specifier: ^1.11.0
+        version: 1.11.0
+      babel-preset-solid:
+        specifier: ^1.7.7
+        version: 1.7.7(@babel/core@7.22.9)
 
 packages:
 
@@ -113,8 +133,20 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
+  /@babel/code-frame@7.22.5:
+    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.5
+    dev: true
+
   /@babel/compat-data@7.20.0:
     resolution: {integrity: sha512-Gt9jszFJYq7qzXVK4slhc6NzJXnOVmRECWcVjF/T23rNXD9NtWQ0W3qxdg+p9wWIB+VQw3GYV/U2Ha9bRTfs4w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/compat-data@7.22.9:
+    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -141,12 +173,45 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core@7.22.9:
+    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator@7.20.0:
     resolution: {integrity: sha512-GUPcXxWibClgmYJuIwC2Bc2Lg+8b9VjaJ+HlNdACEVt+Wlr1eoU1OPZjZRm7Hzl0gaTsUZNQfeihvZJhG7oc3w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.0
       '@jridgewell/gen-mapping': 0.3.2
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator@7.22.9:
+    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
     dev: true
 
@@ -176,6 +241,20 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
+    dev: true
+
+  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.22.9
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.9
+      lru-cache: 5.1.1
+      semver: 6.3.1
     dev: true
 
   /@babel/helper-create-class-features-plugin@7.19.0(@babel/core@7.19.6):
@@ -228,6 +307,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-environment-visitor@7.22.5:
+    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-explode-assignable-expression@7.18.6:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
@@ -243,11 +327,26 @@ packages:
       '@babel/types': 7.20.0
     dev: true
 
+  /@babel/helper-function-name@7.22.5:
+    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.0
+    dev: true
+
+  /@babel/helper-hoist-variables@7.22.5:
+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.18.9:
@@ -264,6 +363,13 @@ packages:
       '@babel/types': 7.20.0
     dev: true
 
+  /@babel/helper-module-imports@7.22.5:
+    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-module-transforms@7.19.6:
     resolution: {integrity: sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==}
     engines: {node: '>=6.9.0'}
@@ -278,6 +384,20 @@ packages:
       '@babel/types': 7.20.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
     dev: true
 
   /@babel/helper-optimise-call-expression@7.18.6:
@@ -327,6 +447,13 @@ packages:
       '@babel/types': 7.20.0
     dev: true
 
+  /@babel/helper-simple-access@7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
@@ -341,8 +468,20 @@ packages:
       '@babel/types': 7.20.0
     dev: true
 
+  /@babel/helper-split-export-declaration@7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-string-parser@7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -351,8 +490,18 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-option@7.18.6:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option@7.22.5:
+    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -379,11 +528,31 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers@7.22.6:
+    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@babel/highlight@7.22.5:
+    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
@@ -394,6 +563,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.0
+    dev: true
+
+  /@babel/parser@7.22.7:
+    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.19.6):
@@ -692,6 +869,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.22.9):
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
@@ -1361,6 +1548,15 @@ packages:
       '@babel/types': 7.20.0
     dev: true
 
+  /@babel/template@7.22.5:
+    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/traverse@7.20.0:
     resolution: {integrity: sha512-5+cAXQNARgjRUK0JWu2UBwja4JLSO/rBMPJzpsKb+oBF5xlUuCfljQepS4XypBQoiigL0VQjTZy6WiONtUdScQ==}
     engines: {node: '>=6.9.0'}
@@ -1379,12 +1575,39 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse@7.22.8:
+    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types@7.20.0:
     resolution: {integrity: sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types@7.22.5:
+    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
     dev: true
 
@@ -2430,6 +2653,19 @@ packages:
       '@types/babel__traverse': 7.18.2
     dev: true
 
+  /babel-plugin-jsx-dom-expressions@0.36.10(@babel/core@7.22.9):
+    resolution: {integrity: sha512-QA2k/14WGw+RgcGGnEuLWwnu4em6CGhjeXtjvgOYyFHYS2a+CzPeaVQHDOlfuiBcjq/3hWMspHMIMnPEOIzdBg==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.22.9)
+      '@babel/types': 7.22.5
+      html-entities: 2.3.3
+      validate-html-nesting: 1.2.2
+    dev: true
+
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.19.6):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
@@ -2497,6 +2733,15 @@ packages:
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.19.6)
     dev: true
 
+  /babel-preset-solid@1.7.7(@babel/core@7.22.9):
+    resolution: {integrity: sha512-tdxVzx3kgcIjNXAOmGRbzIhFBPeJjSakiN9yM+IYdL/+LtXNnbGqb0Va5tJb8Sjbk+QVEriovCyuzB5T7jeTvg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      babel-plugin-jsx-dom-expressions: 0.36.10(@babel/core@7.22.9)
+    dev: true
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -2533,6 +2778,17 @@ packages:
       electron-to-chromium: 1.4.284
       node-releases: 2.0.6
       update-browserslist-db: 1.0.10(browserslist@4.21.4)
+    dev: true
+
+  /browserslist@4.21.9:
+    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001515
+      electron-to-chromium: 1.4.459
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.9)
     dev: true
 
   /bser@2.1.1:
@@ -2591,6 +2847,10 @@ packages:
 
   /caniuse-lite@1.0.30001427:
     resolution: {integrity: sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ==}
+    dev: true
+
+  /caniuse-lite@1.0.30001515:
+    resolution: {integrity: sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==}
     dev: true
 
   /chalk@2.4.2:
@@ -2840,6 +3100,10 @@ packages:
 
   /electron-to-chromium@1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+    dev: true
+
+  /electron-to-chromium@1.4.459:
+    resolution: {integrity: sha512-XXRS5NFv8nCrBL74Rm3qhJjA2VCsRFx0OjHKBMPI0otij56aun8UWiKTDABmd5/7GTR021pA4wivs+Ri6XCElg==}
     dev: true
 
   /emittery@0.8.1:
@@ -3406,6 +3670,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       whatwg-encoding: 1.0.5
+    dev: true
+
+  /html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
     dev: true
 
   /html-escaper@2.0.2:
@@ -4190,6 +4458,12 @@ packages:
     hasBin: true
     dev: true
 
+  /json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: true
+
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
@@ -4266,6 +4540,12 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+
+  /lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
+    dev: true
 
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -4414,6 +4694,10 @@ packages:
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+    dev: true
+
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
     dev: true
 
   /node-releases@2.0.6:
@@ -4884,6 +5168,11 @@ packages:
     hasBin: true
     dev: true
 
+  /semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+    dev: true
+
   /semver@7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
@@ -4891,6 +5180,11 @@ packages:
     dependencies:
       lru-cache: 6.0.0
     dev: true
+
+  /seroval@0.5.1:
+    resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
+    engines: {node: '>=10'}
+    dev: false
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4916,6 +5210,13 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
     dev: true
+
+  /solid-js@1.7.8:
+    resolution: {integrity: sha512-XHBWk1FvFd0JMKljko7FfhefJMTSgYEuVKcQ2a8hzRXfiuSJAGsrPPafqEo+f6l+e8Oe3cROSpIL6kbzjC1fjQ==}
+    dependencies:
+      csstype: 3.1.1
+      seroval: 0.5.1
+    dev: false
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
@@ -5302,6 +5603,17 @@ packages:
       picocolors: 1.0.0
     dev: true
 
+  /update-browserslist-db@1.0.11(browserslist@4.21.9):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.9
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
     dependencies:
@@ -5320,6 +5632,10 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
       source-map: 0.7.4
+    dev: true
+
+  /validate-html-nesting@1.2.2:
+    resolution: {integrity: sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==}
     dev: true
 
   /validate-npm-package-license@3.0.4:
@@ -5479,6 +5795,10 @@ packages:
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
     dev: true
 
   /yallist@4.0.0:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs",
     "lib": ["DOM", "ESNext"],
     "jsx": "preserve",


### PR DESCRIPTION
@TheMightyPenguin Hey there! Got a PR for you.


## Goal

This PR will add Solid support with the same API as the React package. 

## Concerns

- I saw errors in a Solid Start (Vite) app with the TS target set to `es5`. When set to at least `es2015`, the errors went away.
- I changed a types a bit, but the hints in the editor all seem okay.

fixes #7 